### PR TITLE
不要な閉じタグを削除しました

### DIFF
--- a/Core/LanguageInfo.xml
+++ b/Core/LanguageInfo.xml
@@ -12,6 +12,5 @@
       <roleKey>Credit_Translator</roleKey>
       <creditee>Folexe</creditee>
     </li>
-    </li>
   </credits>
 </LanguageInfo>


### PR DESCRIPTION
RimWorld起動時にエラーが発生したため、原因を調査したところ、こちらのXMLファイルに不必要な閉じタグを確認しました。僭越ながら修正リクエストを送らせていただきます。