### PR TITLE
既存翻訳一部修正＋α

### DIFF
--- a/Ideology/DefInjected/QuestScriptDef/Script_Loot_AncientComplex.xml
+++ b/Ideology/DefInjected/QuestScriptDef/Script_Loot_AncientComplex.xml
@@ -34,7 +34,7 @@
     <li>finalWord->booty</li>
   -->
   <OpportunitySite_AncientComplex.questNameRules.rulesStrings>
-    <li>questName(p=3)->[complexAdj] [complex] の [finalWord]</li>
+    <li>questName(p=3)->[complexAdj][complex]の[finalWord]</li>
     <li>questName->[complex] [finalWord]</li>
     <li>complexAdj->秘密の</li>
     <li>complexAdj->神秘的な</li>

--- a/Ideology/DefInjected/QuestScriptDef/Script_WorkSite.xml
+++ b/Ideology/DefInjected/QuestScriptDef/Script_WorkSite.xml
@@ -24,7 +24,7 @@
     <li>detected->uncovered</li>
   -->
   <OpportunitySite_WorkSite.questNameRules.rulesStrings>
-    <li>questName->[site_label] [detected]</li>
+    <li>questName->[site_label][detected]</li>
     <li>detected->を探知</li>
     <li>detected->を発見</li>
     <li>detected->の近郊</li>

--- a/Ideology/DefInjected/RitualBehaviorDef/Ritual_Behaviors.xml
+++ b/Ideology/DefInjected/RitualBehaviorDef/Ritual_Behaviors.xml
@@ -20,9 +20,9 @@
   <!-- EN: Participants -->
   <CelebrationPartyDanceDrum.spectatorsLabel>参加者</CelebrationPartyDanceDrum.spectatorsLabel>
   <!-- EN: Campfire is missing. -->
-  <CelebrationPartyDanceDrum.stages.0.failTriggers.0.desc>キャンプファイヤーがありません.</CelebrationPartyDanceDrum.stages.0.failTriggers.0.desc>
+  <CelebrationPartyDanceDrum.stages.0.failTriggers.0.desc>焚き火がありません.</CelebrationPartyDanceDrum.stages.0.failTriggers.0.desc>
   <!-- EN: Campfire is not lit. -->
-  <CelebrationPartyDanceDrum.stages.0.failTriggers.1.desc>キャンプファイヤーに点火されてません.</CelebrationPartyDanceDrum.stages.0.failTriggers.1.desc>
+  <CelebrationPartyDanceDrum.stages.0.failTriggers.1.desc>焚き火に点火されてません.</CelebrationPartyDanceDrum.stages.0.failTriggers.1.desc>
   <!-- EN: No drums. -->
   <CelebrationPartyDanceDrum.stages.0.failTriggers.2.desc>太鼓がありません.</CelebrationPartyDanceDrum.stages.0.failTriggers.2.desc>
   

--- a/Ideology/DefInjected/RitualOutcomeEffectDef/Ritual_Outcomes.xml
+++ b/Ideology/DefInjected/RitualOutcomeEffectDef/Ritual_Outcomes.xml
@@ -145,9 +145,9 @@
   <!-- EN: played drum count -->
   <CelebrationPartyDanceDrum.comps.2.label>使用している太鼓の数</CelebrationPartyDanceDrum.comps.2.label>
   <!-- EN: started at campfire -->
-  <CelebrationPartyDanceDrum.comps.3.label>キャンプファイヤーで始める</CelebrationPartyDanceDrum.comps.3.label>
+  <CelebrationPartyDanceDrum.comps.3.label>焚き火で始める</CelebrationPartyDanceDrum.comps.3.label>
   <!-- EN: a campfire -->
-  <CelebrationPartyDanceDrum.comps.3.expectedThingLabelTip>キャンプファイヤー</CelebrationPartyDanceDrum.comps.3.expectedThingLabelTip>
+  <CelebrationPartyDanceDrum.comps.3.expectedThingLabelTip>焚き火</CelebrationPartyDanceDrum.comps.3.expectedThingLabelTip>
   <!-- EN: If the {0} is fun or unforgettable, participants may gain increased work speed for a while. -->
   <CelebrationPartyDanceDrum.extraPredictedOutcomeDescriptions.0>{0}が楽しいか忘れられない体験であった場合,参加者は作業速度が上がる効果をしばらくの間得られます.</CelebrationPartyDanceDrum.extraPredictedOutcomeDescriptions.0>
   <!-- EN: Terrible -->

--- a/Ideology/DefInjected/ThingDef/Plants_Special.xml
+++ b/Ideology/DefInjected/ThingDef/Plants_Special.xml
@@ -4,7 +4,7 @@
   <!-- EN: dye -->
   <Dye.label>染料</Dye.label>
   <!-- EN: Dye extracted from a tinctoria plant. It can be transformed into various colors to dye apparel. -->
-  <Dye.description>ティントリアから抽出された染料です.様々な色に変化させて衣服の染色に用います.</Dye.description>
+  <Dye.description>ティンクトリアから抽出された染料です.様々な色に変化させて衣服の染色に用います.</Dye.description>
   
   <!-- EN: Gauranlen seed -->
   <GauranlenSeed.label>ガウランレンの種</GauranlenSeed.label>

--- a/Ideology/DefInjected/ThoughtDef/Precepts_IdeoDiversity.xml
+++ b/Ideology/DefInjected/ThoughtDef/Precepts_IdeoDiversity.xml
@@ -17,17 +17,17 @@
   <IdeoDiverity_Horrible_AltarSharing.stages.false_altar.description>TODO</IdeoDiverity_Horrible_AltarSharing.stages.false_altar.description>
   
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.label>TODO</IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.label>
+  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.label>多様な考え</IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.label>
   <!-- EN: My truth is so pure and obvious, yet some of those around me are captured by evil. It's abhorrent. -->
-  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.description>TODO</IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.description>
+  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.description>私の真実はとても純粋で明白なのに,私の周りの一部の人が邪悪な考えに捕らわれている.忌まわしいことだ.</IdeoDiversity_Abhorrent.stages.diverse_thoughts-0.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.label>TODO</IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.label>
+  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.label>多様な考え</IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.label>
   <!-- EN: My truth is so pure and obvious, yet many of those around me are captured by evil. It's abhorrent. -->
-  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.description>TODO</IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.description>
+  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.description>私の真実はとても純粋で明白なのに,私の周りの多くの人が邪悪な考えに捕らわれている.忌まわしいことだ.</IdeoDiversity_Abhorrent.stages.diverse_thoughts-1.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.label>TODO</IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.label>
+  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.label>多様な考え</IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.label>
   <!-- EN: My truth is so pure and obvious, yet almost all of those around me are captured by evil. It's abhorrent. -->
-  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.description>TODO</IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.description>
+  <IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.description>私の真実はとても純粋で明白なのに,私の周りの全員が邪悪な考えに捕らわれている.忌まわしいことだ.</IdeoDiversity_Abhorrent.stages.diverse_thoughts-2.description>
   
   <!-- EN: different ideoligion -->
   <IdeoDiversity_Abhorrent_Social.stages.different_ideoligion.label>TODO</IdeoDiversity_Abhorrent_Social.stages.different_ideoligion.label>
@@ -35,11 +35,11 @@
   <!-- EN: {ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Abhorrent_StyleDominance.stages.style_surroundings.label>{ADJECTIVE}スタイルの環境</IdeoDiversity_Abhorrent_StyleDominance.stages.style_surroundings.label>
   <!-- EN: I am surrounded by constructions which match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Abhorrent_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルに一致した構造物に囲まれている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Abhorrent_StyleDominance.stages.style_surroundings.description>
+  <IdeoDiversity_Abhorrent_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念と合うスタイルの構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Abhorrent_StyleDominance.stages.style_surroundings.description>
   <!-- EN: Non-{ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Abhorrent_StyleDominance.stages.Nonstyle_surroundings.label>非{ADJECTIVE}スタイルの環境</IdeoDiversity_Abhorrent_StyleDominance.stages.Nonstyle_surroundings.label>
   <!-- EN: I am surrounded by constructions that do not match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Abhorrent_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルと一致しない構造物に悩まされている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Abhorrent_StyleDominance.stages.Nonstyle_surroundings.description>
+  <IdeoDiversity_Abhorrent_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念に合わない構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Abhorrent_StyleDominance.stages.Nonstyle_surroundings.description>
   
   <!-- EN: uniform thoughts -->
   <IdeoDiversity_Abhorrent_Uniform.stages.uniform_thoughts.label>統一された考え</IdeoDiversity_Abhorrent_Uniform.stages.uniform_thoughts.label>
@@ -47,15 +47,15 @@
   <IdeoDiversity_Abhorrent_Uniform.stages.uniform_thoughts.description>私たちのコミュニティは,当然のことながら,邪悪な考えから解放されている.</IdeoDiversity_Abhorrent_Uniform.stages.uniform_thoughts.description>
   
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Approved.stages.diverse_thoughts-0.label>TODO</IdeoDiversity_Approved.stages.diverse_thoughts-0.label>
+  <IdeoDiversity_Approved.stages.diverse_thoughts-0.label>多様な考え</IdeoDiversity_Approved.stages.diverse_thoughts-0.label>
   <!-- EN: Some others here have different beliefs. It's a sign of a healthy community. -->
   <IdeoDiversity_Approved.stages.diverse_thoughts-0.description>TODO</IdeoDiversity_Approved.stages.diverse_thoughts-0.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Approved.stages.diverse_thoughts-1.label>TODO</IdeoDiversity_Approved.stages.diverse_thoughts-1.label>
+  <IdeoDiversity_Approved.stages.diverse_thoughts-1.label>多様な考え</IdeoDiversity_Approved.stages.diverse_thoughts-1.label>
   <!-- EN: Many others here have different beliefs. It's a sign of a healthy community. -->
   <IdeoDiversity_Approved.stages.diverse_thoughts-1.description>TODO</IdeoDiversity_Approved.stages.diverse_thoughts-1.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Approved.stages.diverse_thoughts-2.label>TODO</IdeoDiversity_Approved.stages.diverse_thoughts-2.label>
+  <IdeoDiversity_Approved.stages.diverse_thoughts-2.label>多様な考え</IdeoDiversity_Approved.stages.diverse_thoughts-2.label>
   <!-- EN: Almost all others here have different beliefs. It's a sign of a healthy community. -->
   <IdeoDiversity_Approved.stages.diverse_thoughts-2.description>TODO</IdeoDiversity_Approved.stages.diverse_thoughts-2.description>
   
@@ -69,15 +69,15 @@
   <IdeoDiversity_Approved_StyleDominance.stages.Non_surroundings.description>私の周りは全く{ADJECTIVE}環境ではない.多様性を楽しんでいる.</IdeoDiversity_Approved_StyleDominance.stages.Non_surroundings.description>
   
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Disapproved.stages.diverse_thoughts-0.label>TODO</IdeoDiversity_Disapproved.stages.diverse_thoughts-0.label>
+  <IdeoDiversity_Disapproved.stages.diverse_thoughts-0.label>多様な考え</IdeoDiversity_Disapproved.stages.diverse_thoughts-0.label>
   <!-- EN: My truth is clear, yet some of those around me are so foolish they can't see it. I don't like being subjected to their idiocy. -->
   <IdeoDiversity_Disapproved.stages.diverse_thoughts-0.description>TODO</IdeoDiversity_Disapproved.stages.diverse_thoughts-0.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Disapproved.stages.diverse_thoughts-1.label>TODO</IdeoDiversity_Disapproved.stages.diverse_thoughts-1.label>
+  <IdeoDiversity_Disapproved.stages.diverse_thoughts-1.label>多様な考え</IdeoDiversity_Disapproved.stages.diverse_thoughts-1.label>
   <!-- EN: My truth is clear, yet many of those around me are so foolish they can't see it. I don't like being subjected to their idiocy. -->
   <IdeoDiversity_Disapproved.stages.diverse_thoughts-1.description>TODO</IdeoDiversity_Disapproved.stages.diverse_thoughts-1.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Disapproved.stages.diverse_thoughts-2.label>TODO</IdeoDiversity_Disapproved.stages.diverse_thoughts-2.label>
+  <IdeoDiversity_Disapproved.stages.diverse_thoughts-2.label>多様な考え</IdeoDiversity_Disapproved.stages.diverse_thoughts-2.label>
   <!-- EN: My truth is clear, yet almost all of those around me are so foolish they can't see it. I don't like being subjected to their idiocy. -->
   <IdeoDiversity_Disapproved.stages.diverse_thoughts-2.description>TODO</IdeoDiversity_Disapproved.stages.diverse_thoughts-2.description>
   
@@ -87,11 +87,11 @@
   <!-- EN: {ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Disapproved_StyleDominance.stages.style_surroundings.label>{ADJECTIVE}スタイルの環境</IdeoDiversity_Disapproved_StyleDominance.stages.style_surroundings.label>
   <!-- EN: I am surrounded by constructions which match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Disapproved_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルに一致した構造物に囲まれている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Disapproved_StyleDominance.stages.style_surroundings.description>
+  <IdeoDiversity_Disapproved_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念と合うスタイルの構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Disapproved_StyleDominance.stages.style_surroundings.description>
   <!-- EN: Non-{ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Disapproved_StyleDominance.stages.Nonstyle_surroundings.label>非{ADJECTIVE}スタイルの環境</IdeoDiversity_Disapproved_StyleDominance.stages.Nonstyle_surroundings.label>
   <!-- EN: I am surrounded by constructions that do not match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Disapproved_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルと一致しない構造物に悩まされている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Disapproved_StyleDominance.stages.Nonstyle_surroundings.description>
+  <IdeoDiversity_Disapproved_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念に合わない構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Disapproved_StyleDominance.stages.Nonstyle_surroundings.description>
   
   <!-- EN: uniform thoughts -->
   <IdeoDiversity_Disapproved_Uniform.stages.uniform_thoughts.label>統一された考え</IdeoDiversity_Disapproved_Uniform.stages.uniform_thoughts.label>
@@ -99,15 +99,15 @@
   <IdeoDiversity_Disapproved_Uniform.stages.uniform_thoughts.description>私たちのコミュニティは,当然のことながら,愚かさから解放されている.</IdeoDiversity_Disapproved_Uniform.stages.uniform_thoughts.description>
   
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Exalted.stages.diverse_thoughts-0.label>TODO</IdeoDiversity_Exalted.stages.diverse_thoughts-0.label>
+  <IdeoDiversity_Exalted.stages.diverse_thoughts-0.label>多様な考え</IdeoDiversity_Exalted.stages.diverse_thoughts-0.label>
   <!-- EN: Some others here have different beliefs. I'm so proud to be part of such a community. -->
   <IdeoDiversity_Exalted.stages.diverse_thoughts-0.description>TODO</IdeoDiversity_Exalted.stages.diverse_thoughts-0.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Exalted.stages.diverse_thoughts-1.label>TODO</IdeoDiversity_Exalted.stages.diverse_thoughts-1.label>
+  <IdeoDiversity_Exalted.stages.diverse_thoughts-1.label>多様な考え</IdeoDiversity_Exalted.stages.diverse_thoughts-1.label>
   <!-- EN: Many others here have different beliefs. I'm so proud to be part of such a community. -->
   <IdeoDiversity_Exalted.stages.diverse_thoughts-1.description>TODO</IdeoDiversity_Exalted.stages.diverse_thoughts-1.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Exalted.stages.diverse_thoughts-2.label>TODO</IdeoDiversity_Exalted.stages.diverse_thoughts-2.label>
+  <IdeoDiversity_Exalted.stages.diverse_thoughts-2.label>多様な考え</IdeoDiversity_Exalted.stages.diverse_thoughts-2.label>
   <!-- EN: Almost all others here have different beliefs. I'm so proud to be part of such a community. -->
   <IdeoDiversity_Exalted.stages.diverse_thoughts-2.description>TODO</IdeoDiversity_Exalted.stages.diverse_thoughts-2.description>
   
@@ -121,15 +121,15 @@
   <IdeoDiversity_Exalted_StyleDominance.stages.Non_surroundings.description>私の周りは全く{ADJECTIVE}環境ではない.この多様なコミュニティの一員であることにとても満足している.</IdeoDiversity_Exalted_StyleDominance.stages.Non_surroundings.description>
   
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Horrible.stages.diverse_thoughts-0.label>TODO</IdeoDiversity_Horrible.stages.diverse_thoughts-0.label>
+  <IdeoDiversity_Horrible.stages.diverse_thoughts-0.label>多様な考え</IdeoDiversity_Horrible.stages.diverse_thoughts-0.label>
   <!-- EN: My truth is so obvious, yet some of those around me are so deluded. It's horrible. -->
   <IdeoDiversity_Horrible.stages.diverse_thoughts-0.description>TODO</IdeoDiversity_Horrible.stages.diverse_thoughts-0.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Horrible.stages.diverse_thoughts-1.label>TODO</IdeoDiversity_Horrible.stages.diverse_thoughts-1.label>
+  <IdeoDiversity_Horrible.stages.diverse_thoughts-1.label>多様な考え</IdeoDiversity_Horrible.stages.diverse_thoughts-1.label>
   <!-- EN: My truth is so obvious, yet many those around me are so deluded. It's horrible. -->
   <IdeoDiversity_Horrible.stages.diverse_thoughts-1.description>TODO</IdeoDiversity_Horrible.stages.diverse_thoughts-1.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Horrible.stages.diverse_thoughts-2.label>TODO</IdeoDiversity_Horrible.stages.diverse_thoughts-2.label>
+  <IdeoDiversity_Horrible.stages.diverse_thoughts-2.label>多様な考え</IdeoDiversity_Horrible.stages.diverse_thoughts-2.label>
   <!-- EN: My truth is so obvious, yet almost all of those around me are so deluded. It's horrible. -->
   <IdeoDiversity_Horrible.stages.diverse_thoughts-2.description>TODO</IdeoDiversity_Horrible.stages.diverse_thoughts-2.description>
   
@@ -139,11 +139,11 @@
   <!-- EN: {ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Horrible_StyleDominance.stages.style_surroundings.label>{ADJECTIVE}スタイルの環境</IdeoDiversity_Horrible_StyleDominance.stages.style_surroundings.label>
   <!-- EN: I am surrounded by constructions which match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Horrible_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルに一致した構造物に囲まれている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Horrible_StyleDominance.stages.style_surroundings.description>
+  <IdeoDiversity_Horrible_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念と合うスタイルの構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Horrible_StyleDominance.stages.style_surroundings.description>
   <!-- EN: Non-{ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Horrible_StyleDominance.stages.Nonstyle_surroundings.label>非{ADJECTIVE}スタイルの環境</IdeoDiversity_Horrible_StyleDominance.stages.Nonstyle_surroundings.label>
   <!-- EN: I am surrounded by constructions that do not match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Horrible_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルと一致しない構造物に悩まされている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Horrible_StyleDominance.stages.Nonstyle_surroundings.description>
+  <IdeoDiversity_Horrible_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念に合わない構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Horrible_StyleDominance.stages.Nonstyle_surroundings.description>
   
   <!-- EN: uniform thoughts -->
   <IdeoDiversity_Horrible_Uniform.stages.uniform_thoughts.label>統一された考え</IdeoDiversity_Horrible_Uniform.stages.uniform_thoughts.label>
@@ -151,15 +151,15 @@
   <IdeoDiversity_Horrible_Uniform.stages.uniform_thoughts.description>私たちのコミュニティには,当然のことながら,不潔な妄想がない.</IdeoDiversity_Horrible_Uniform.stages.uniform_thoughts.description>
   
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Respected.stages.diverse_thoughts-0.label>TODO</IdeoDiversity_Respected.stages.diverse_thoughts-0.label>
+  <IdeoDiversity_Respected.stages.diverse_thoughts-0.label>多様な考え</IdeoDiversity_Respected.stages.diverse_thoughts-0.label>
   <!-- EN: Some others here have different beliefs. It's an important sign of a healthy community. -->
   <IdeoDiversity_Respected.stages.diverse_thoughts-0.description>TODO</IdeoDiversity_Respected.stages.diverse_thoughts-0.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Respected.stages.diverse_thoughts-1.label>TODO</IdeoDiversity_Respected.stages.diverse_thoughts-1.label>
+  <IdeoDiversity_Respected.stages.diverse_thoughts-1.label>多様な考え</IdeoDiversity_Respected.stages.diverse_thoughts-1.label>
   <!-- EN: Many others here have different beliefs. It's an important sign of a healthy community. -->
   <IdeoDiversity_Respected.stages.diverse_thoughts-1.description>TODO</IdeoDiversity_Respected.stages.diverse_thoughts-1.description>
   <!-- EN: diverse thoughts -->
-  <IdeoDiversity_Respected.stages.diverse_thoughts-2.label>TODO</IdeoDiversity_Respected.stages.diverse_thoughts-2.label>
+  <IdeoDiversity_Respected.stages.diverse_thoughts-2.label>多様な考え</IdeoDiversity_Respected.stages.diverse_thoughts-2.label>
   <!-- EN: Almost all others here have different beliefs. It's an important sign of a healthy community. -->
   <IdeoDiversity_Respected.stages.diverse_thoughts-2.description>TODO</IdeoDiversity_Respected.stages.diverse_thoughts-2.description>
   
@@ -175,10 +175,10 @@
   <!-- EN: {ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Standard_StyleDominance.stages.style_surroundings.label>{ADJECTIVE}スタイルの環境</IdeoDiversity_Standard_StyleDominance.stages.style_surroundings.label>
   <!-- EN: I am surrounded by constructions which match the style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Standard_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルに一致した構造物に囲まれている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Standard_StyleDominance.stages.style_surroundings.description>
+  <IdeoDiversity_Standard_StyleDominance.stages.style_surroundings.description>私は,{ADJECTIVE}信念と合うスタイルの構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Standard_StyleDominance.stages.style_surroundings.description>
   <!-- EN: Non-{ADJECTIVE}-style surroundings -->
   <IdeoDiversity_Standard_StyleDominance.stages.Nonstyle_surroundings.label>非{ADJECTIVE}スタイルの環境</IdeoDiversity_Standard_StyleDominance.stages.Nonstyle_surroundings.label>
   <!-- EN: I am surrounded by non-{ADJECTIVE} constructions. That's fine, but I'd prefer being in a more {ADJECTIVE} environment with constructions that match style(s) that reflect my {ADJECTIVE} beliefs. My beliefs are reflected by these styles: {STYLES} -->
-  <IdeoDiversity_Standard_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念を反映したスタイルと一致しない構造物に悩まされている.私の信念は,これらのスタイルに反映されている: {STYLES}</IdeoDiversity_Standard_StyleDominance.stages.Nonstyle_surroundings.description>
+  <IdeoDiversity_Standard_StyleDominance.stages.Nonstyle_surroundings.description>私は,{ADJECTIVE}信念に合わない構造物に囲まれている.私の信念: {STYLES}</IdeoDiversity_Standard_StyleDominance.stages.Nonstyle_surroundings.description>
   
 </LanguageData>

--- a/Ideology/Keyed/Dialogs_Various.xml
+++ b/Ideology/Keyed/Dialogs_Various.xml
@@ -74,27 +74,27 @@
   <CannotBeWornWith>TODO</CannotBeWornWith>
 
   <!-- EN: Certainty reduction -->
-  <AbilityIdeoConvertBreakdownLabel>TODO</AbilityIdeoConvertBreakdownLabel>
+  <AbilityIdeoConvertBreakdownLabel>信仰度の減少</AbilityIdeoConvertBreakdownLabel>
   <!-- EN: Using {ABILITY} ability -->
-  <AbilityIdeoConvertBreakdownUsingAbility>TODO</AbilityIdeoConvertBreakdownUsingAbility>
+  <AbilityIdeoConvertBreakdownUsingAbility>{ABILITY}アビリティの使用</AbilityIdeoConvertBreakdownUsingAbility>
   <!-- EN: {PAWN_labelShort}'s conversion power -->
-  <AbilityIdeoConvertBreakdownConversionPower>TODO</AbilityIdeoConvertBreakdownConversionPower>
+  <AbilityIdeoConvertBreakdownConversionPower>{PAWN_labelShort}の改宗させる力</AbilityIdeoConvertBreakdownConversionPower>
   <!-- EN: {PAWN_labelShort}'s certainty loss factor from {IDEO_name} -->
-  <AbilityIdeoConvertBreakdownIdeoCertaintyReduction>TODO</AbilityIdeoConvertBreakdownIdeoCertaintyReduction>
+  <AbilityIdeoConvertBreakdownIdeoCertaintyReduction>{PAWN_labelShort}の{IDEO_name}信仰度損失率</AbilityIdeoConvertBreakdownIdeoCertaintyReduction>
   <!-- EN: {PAWN_labelShort} is {ROLE_labelDef} -->
-  <AbilityIdeoConvertBreakdownRole>TODO</AbilityIdeoConvertBreakdownRole>
+  <AbilityIdeoConvertBreakdownRole>{PAWN_labelShort}が{ROLE_labelDef}</AbilityIdeoConvertBreakdownRole>
   <!-- EN: Trait {TRAIT} -->
-  <AbilityIdeoConvertBreakdownTrait>TODO</AbilityIdeoConvertBreakdownTrait>
+  <AbilityIdeoConvertBreakdownTrait>{TRAIT}</AbilityIdeoConvertBreakdownTrait>
   <!-- EN: {RELICCOUNT} installed relics on map -->
   <AbilityIdeoConvertBreakdownRelic>TODO</AbilityIdeoConvertBreakdownRelic>
   <!-- EN: {PAWN_labelShort}'s social skill -->
-  <AbilityIdeoConvertBreakdownSocialSkill>TODO</AbilityIdeoConvertBreakdownSocialSkill>
+  <AbilityIdeoConvertBreakdownSocialSkill>{PAWN_labelShort}の社交スキル</AbilityIdeoConvertBreakdownSocialSkill>
   <!-- EN: {RECIPIENT_labelShort}'s opinion of {INITIATOR_labelShort} -->
-  <AbilityIdeoConvertBreakdownOpinion>TODO</AbilityIdeoConvertBreakdownOpinion>
+  <AbilityIdeoConvertBreakdownOpinion>{RECIPIENT_labelShort}の{INITIATOR_labelShort}に対する意見</AbilityIdeoConvertBreakdownOpinion>
   <!-- EN: {PAWN_nameDef}'s ideoligion -->
-  <AbilityIdeoConvertBreakdownPawnIdeo>TODO</AbilityIdeoConvertBreakdownPawnIdeo>
+  <AbilityIdeoConvertBreakdownPawnIdeo>{PAWN_nameDef}の思想</AbilityIdeoConvertBreakdownPawnIdeo>
   <!-- EN: {MEME} vs {TRAIT} trait -->
-  <AbilityIdeoConvertBreakdownMemeVsTrait>TODO</AbilityIdeoConvertBreakdownMemeVsTrait>
+  <AbilityIdeoConvertBreakdownMemeVsTrait>{MEME} vs {TRAIT}</AbilityIdeoConvertBreakdownMemeVsTrait>
 
   <!-- EN: {PAWN_labelShort} was already counselled recently. -->
   <AbilityCantApplyAlreadyCounselled>TODO</AbilityCantApplyAlreadyCounselled>

--- a/Ideology/Keyed/Misc_Gameplay.xml
+++ b/Ideology/Keyed/Misc_Gameplay.xml
@@ -76,7 +76,7 @@
   <!-- EN: Chance to have precept -->
   <ChanceToHavePrecept>確率で戒律を覚える</ChanceToHavePrecept>
   <!-- EN: {PAWN_labelShort}'s favorite color. Having more than {PERCENTAGE} of {PAWN_possessive} apparel in this color, or the color of {PAWN_possessive} ideoligion, will make {PAWN_objective} slightly happier.\n\nYou can alter apparel colors at the styling station using tinctoria dye. -->
-  <FavoriteColorTooltip>{PAWN_labelShort}の好きな色です.着ている衣服の{PERCENTAGE}以上がこの色,もしくは{PAWN_possessive}持つ思想の色であると,{PAWN_pronoun}は少し幸せになります.\n\nティンクトリア染料を使用して,スタイリングステーションで衣服の色を変更できます.</FavoriteColorTooltip>
+  <FavoriteColorTooltip>{PAWN_labelShort}の好きな色です.着ている衣服の{PERCENTAGE}以上がこの色,もしくは{PAWN_possessive}持つ思想の色であると,{PAWN_pronoun}は少し幸せになります.\n\nティンクトリア染料を使用して,化粧台で衣服の色を変更できます.</FavoriteColorTooltip>
   <!-- EN: Set ideo color -->
   <SetIdeoColor>思想の色に設定</SetIdeoColor>
   <!-- EN: Set to favorite color -->
@@ -134,17 +134,17 @@
   <!-- EN: No powered speakers. -->
   <RitualTargetNoPoweredSpeakers>ラウドスピーカーに電力が供給されてません.</RitualTargetNoPoweredSpeakers>
   <!-- EN: Campfire is not fueled. -->
-  <RitualTargetCampfireNoFuel>キャンプファイヤーに燃料がありません.</RitualTargetCampfireNoFuel>
+  <RitualTargetCampfireNoFuel>焚き火に燃料がありません.</RitualTargetCampfireNoFuel>
   <!-- EN: Campfire must be unroofed. -->
-  <RitualTargetCampfireMustBeUnroofed>キャンプファイヤーは屋根のない場所に設置する必要があります.</RitualTargetCampfireMustBeUnroofed>
+  <RitualTargetCampfireMustBeUnroofed>焚き火は屋根のない場所に設置する必要があります.</RitualTargetCampfireMustBeUnroofed>
   <!-- EN: No nearby drum. -->
   <RitualTargetNoDrum>太鼓のそばではありません.</RitualTargetNoDrum>
   <!-- EN: Need at least {0} unroofed cells nearby. -->
   <RitualTargetNeedUnroofedCells>少なくとも{0}マスの屋根のないセルが近くに必要です.</RitualTargetNeedUnroofedCells>
   <!-- EN: A lit campfire or ritual spot. -->
-  <RitualTargetCampfirePartyInfo>火のついたキャンプファイヤーか儀式の場です.</RitualTargetCampfirePartyInfo>
+  <RitualTargetCampfirePartyInfo>焚き火か儀式の場です.</RitualTargetCampfirePartyInfo>
   <!-- EN: A lit campfire or ritual spot. Spot must be unroofed with at least 25 unroofed cells in the area. -->
-  <RitualTargetCampfireSkylanternsInfo>火のついたキャンプファイヤーか儀式の場です.スポットには屋根がなく,そのエリアに少なくとも25マスの屋根のないセルが必要です.</RitualTargetCampfireSkylanternsInfo>
+  <RitualTargetCampfireSkylanternsInfo>焚き火か儀式の場です.スポットには屋根がなく,そのエリアに少なくとも25マスの屋根のないセルが必要です.</RitualTargetCampfireSkylanternsInfo>
   <!-- EN: An unconnected Gauranlen tree. -->
   <RitualTargetUnconnectedGaruanlenTreeInfo>接続されていないガウランレンツリーです.</RitualTargetUnconnectedGaruanlenTreeInfo>
   <!-- EN: Already connected to {PAWN_nameDef} -->


### PR DESCRIPTION
・空白削除
・ゲーム内で使用するオブジェクト名の統一→アイテム選択時に表示される名称の方に統一しています
　キャンプファイヤー→焚き火
　スタイリングステーション→化粧台
　ティントリア→ティンクトリア
・冗長な翻訳修正
・その他一部追加翻訳