### PR TITLE
WorkGiverDefを翻訳

### DIFF
--- a/Biotech/DefInjected/WorkGiverDef/WorkGivers.xml
+++ b/Biotech/DefInjected/WorkGiverDef/WorkGivers.xml
@@ -1,186 +1,186 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <LanguageData>
   
   <!-- EN: feed babies -->
-  <BottleFeedBaby.label>TODO</BottleFeedBaby.label>
+  <BottleFeedBaby.label>赤ん坊に食事を与える</BottleFeedBaby.label>
   <!-- EN: feeding -->
-  <BottleFeedBaby.gerund>TODO</BottleFeedBaby.gerund>
+  <BottleFeedBaby.gerund>に食事を与える</BottleFeedBaby.gerund>
   <!-- EN: feed -->
-  <BottleFeedBaby.verb>TODO</BottleFeedBaby.verb>
+  <BottleFeedBaby.verb>食事を与える</BottleFeedBaby.verb>
   
   <!-- EN: breastfeed babies -->
-  <BreastfeedBaby.label>TODO</BreastfeedBaby.label>
+  <BreastfeedBaby.label>授乳</BreastfeedBaby.label>
   <!-- EN: breastfeeding -->
-  <BreastfeedBaby.gerund>TODO</BreastfeedBaby.gerund>
+  <BreastfeedBaby.gerund>に授乳する</BreastfeedBaby.gerund>
   <!-- EN: breastfeed -->
-  <BreastfeedBaby.verb>TODO</BreastfeedBaby.verb>
+  <BreastfeedBaby.verb>授乳</BreastfeedBaby.verb>
   
   <!-- EN: bring babies to safe temperature -->
-  <BringBabyToSafety.label>TODO</BringBabyToSafety.label>
+  <BringBabyToSafety.label>赤ん坊を安全な気温へ退避</BringBabyToSafety.label>
   <!-- EN: rescuing -->
-  <BringBabyToSafety.gerund>TODO</BringBabyToSafety.gerund>
+  <BringBabyToSafety.gerund>を救出する</BringBabyToSafety.gerund>
   <!-- EN: rescue -->
-  <BringBabyToSafety.verb>TODO</BringBabyToSafety.verb>
+  <BringBabyToSafety.verb>救出</BringBabyToSafety.verb>
   
   <!-- EN: carry to mother -->
-  <CarryToBreastfeed.label>TODO</CarryToBreastfeed.label>
+  <CarryToBreastfeed.label>母親の元へ運ぶ</CarryToBreastfeed.label>
   <!-- EN: getting mother to breastfeed -->
-  <CarryToBreastfeed.gerund>TODO</CarryToBreastfeed.gerund>
+  <CarryToBreastfeed.gerund>を授乳のため母親の元へ運ぶ</CarryToBreastfeed.gerund>
   <!-- EN: get mother to breastfeed -->
-  <CarryToBreastfeed.verb>TODO</CarryToBreastfeed.verb>
+  <CarryToBreastfeed.verb>母親の元へ運ぶ</CarryToBreastfeed.verb>
   
   <!-- EN: carry to building -->
-  <CarryToGeneExtractor.label>TODO</CarryToGeneExtractor.label>
+  <CarryToGeneExtractor.label>設備へ運搬</CarryToGeneExtractor.label>
   <!-- EN: extracting genes from -->
-  <CarryToGeneExtractor.gerund>TODO</CarryToGeneExtractor.gerund>
+  <CarryToGeneExtractor.gerund>から遺伝子を抽出する</CarryToGeneExtractor.gerund>
   <!-- EN: extract genes -->
-  <CarryToGeneExtractor.verb>TODO</CarryToGeneExtractor.verb>
+  <CarryToGeneExtractor.verb>遺伝子抽出</CarryToGeneExtractor.verb>
   
   <!-- EN: carry to building -->
-  <CarryToGrowthVat.label>TODO</CarryToGrowthVat.label>
+  <CarryToGrowthVat.label>設備へ運搬</CarryToGrowthVat.label>
   <!-- EN: growing -->
-  <CarryToGrowthVat.gerund>TODO</CarryToGrowthVat.gerund>
+  <CarryToGrowthVat.gerund>を成長させる</CarryToGrowthVat.gerund>
   <!-- EN: grow -->
-  <CarryToGrowthVat.verb>TODO</CarryToGrowthVat.verb>
+  <CarryToGrowthVat.verb>成長</CarryToGrowthVat.verb>
   
   <!-- EN: carry to subcore scanner -->
-  <CarryToSubcoreScanner.label>TODO</CarryToSubcoreScanner.label>
+  <CarryToSubcoreScanner.label>サブコアスキャナーへ運搬</CarryToSubcoreScanner.label>
   <!-- EN: carrying -->
-  <CarryToSubcoreScanner.gerund>TODO</CarryToSubcoreScanner.gerund>
+  <CarryToSubcoreScanner.gerund>を運搬</CarryToSubcoreScanner.gerund>
   <!-- EN: carry -->
-  <CarryToSubcoreScanner.verb>TODO</CarryToSubcoreScanner.verb>
+  <CarryToSubcoreScanner.verb>運搬</CarryToSubcoreScanner.verb>
   
   <!-- EN: teach child -->
-  <ChildcarerTeach.label>TODO</ChildcarerTeach.label>
+  <ChildcarerTeach.label>子供を教育</ChildcarerTeach.label>
   <!-- EN: teaching -->
-  <ChildcarerTeach.gerund>TODO</ChildcarerTeach.gerund>
+  <ChildcarerTeach.gerund>を教育する</ChildcarerTeach.gerund>
   <!-- EN: teach -->
-  <ChildcarerTeach.verb>TODO</ChildcarerTeach.verb>
+  <ChildcarerTeach.verb>教育</ChildcarerTeach.verb>
   
   <!-- EN: clean pollution -->
-  <CleanClearPollution.label>TODO</CleanClearPollution.label>
+  <CleanClearPollution.label>除染</CleanClearPollution.label>
   <!-- EN: cleaning pollution -->
-  <CleanClearPollution.gerund>TODO</CleanClearPollution.gerund>
+  <CleanClearPollution.gerund>を除染する</CleanClearPollution.gerund>
   <!-- EN: clean pollution -->
-  <CleanClearPollution.verb>TODO</CleanClearPollution.verb>
+  <CleanClearPollution.verb>除染</CleanClearPollution.verb>
   
   <!-- EN: create xenogerm -->
-  <CreateXenogerm.label>TODO</CreateXenogerm.label>
+  <CreateXenogerm.label>異種胚を作成</CreateXenogerm.label>
   <!-- EN: creating xenogerm at -->
-  <CreateXenogerm.gerund>TODO</CreateXenogerm.gerund>
+  <CreateXenogerm.gerund>の異種胚を作成する</CreateXenogerm.gerund>
   <!-- EN: create xenogerm -->
-  <CreateXenogerm.verb>TODO</CreateXenogerm.verb>
+  <CreateXenogerm.verb>異種胚を作成</CreateXenogerm.verb>
   
   <!-- EN: deliver hemogen to prisoners -->
-  <DeliverHemogenToPrisoner.label>TODO</DeliverHemogenToPrisoner.label>
+  <DeliverHemogenToPrisoner.label>ヘモゲンを囚人へ配達</DeliverHemogenToPrisoner.label>
   <!-- EN: delivering hemogen for -->
-  <DeliverHemogenToPrisoner.gerund>TODO</DeliverHemogenToPrisoner.gerund>
+  <DeliverHemogenToPrisoner.gerund>にヘモゲンを配達する</DeliverHemogenToPrisoner.gerund>
   <!-- EN: deliver hemogen for -->
-  <DeliverHemogenToPrisoner.verb>TODO</DeliverHemogenToPrisoner.verb>
+  <DeliverHemogenToPrisoner.verb>ヘモゲンを配達</DeliverHemogenToPrisoner.verb>
   
   <!-- EN: make things at mech gestator -->
-  <DoBillsMechGestator.label>TODO</DoBillsMechGestator.label>
+  <DoBillsMechGestator.label>メカジェステイターで作成</DoBillsMechGestator.label>
   <!-- EN: working at -->
-  <DoBillsMechGestator.gerund>TODO</DoBillsMechGestator.gerund>
+  <DoBillsMechGestator.gerund>で作成する</DoBillsMechGestator.gerund>
   <!-- EN: work at -->
-  <DoBillsMechGestator.verb>TODO</DoBillsMechGestator.verb>
+  <DoBillsMechGestator.verb>作成</DoBillsMechGestator.verb>
   
   <!-- EN: make things at subcore encoder -->
-  <DoBillsSubcoreEncoder.label>TODO</DoBillsSubcoreEncoder.label>
+  <DoBillsSubcoreEncoder.label>サブコアエンコーダーで作成</DoBillsSubcoreEncoder.label>
   <!-- EN: working at -->
-  <DoBillsSubcoreEncoder.gerund>TODO</DoBillsSubcoreEncoder.gerund>
+  <DoBillsSubcoreEncoder.gerund>で作成する</DoBillsSubcoreEncoder.gerund>
   <!-- EN: work -->
-  <DoBillsSubcoreEncoder.verb>TODO</DoBillsSubcoreEncoder.verb>
+  <DoBillsSubcoreEncoder.verb>作成</DoBillsSubcoreEncoder.verb>
   
   <!-- EN: empty waste container -->
-  <EmptyWasteContainer.label>TODO</EmptyWasteContainer.label>
+  <EmptyWasteContainer.label>廃棄物コンテナを空にする</EmptyWasteContainer.label>
   <!-- EN: extracting from -->
-  <EmptyWasteContainer.gerund>TODO</EmptyWasteContainer.gerund>
+  <EmptyWasteContainer.gerund>から抽出する</EmptyWasteContainer.gerund>
   <!-- EN: extract from -->
-  <EmptyWasteContainer.verb>TODO</EmptyWasteContainer.verb>
+  <EmptyWasteContainer.verb>抽出</EmptyWasteContainer.verb>
   
   <!-- EN: enter gene extractor -->
-  <EnterGeneExtractor.label>TODO</EnterGeneExtractor.label>
+  <EnterGeneExtractor.label>遺伝子抽出機に入る</EnterGeneExtractor.label>
   <!-- EN: entering -->
-  <EnterGeneExtractor.gerund>TODO</EnterGeneExtractor.gerund>
+  <EnterGeneExtractor.gerund>に入る</EnterGeneExtractor.gerund>
   <!-- EN: enter -->
-  <EnterGeneExtractor.verb>TODO</EnterGeneExtractor.verb>
+  <EnterGeneExtractor.verb>入る</EnterGeneExtractor.verb>
   
   <!-- EN: enter growth vat -->
-  <EnterGrowthVat.label>TODO</EnterGrowthVat.label>
+  <EnterGrowthVat.label>成長バットへ入る</EnterGrowthVat.label>
   <!-- EN: entering -->
-  <EnterGrowthVat.gerund>TODO</EnterGrowthVat.gerund>
+  <EnterGrowthVat.gerund>に入る</EnterGrowthVat.gerund>
   <!-- EN: enter -->
-  <EnterGrowthVat.verb>TODO</EnterGrowthVat.verb>
+  <EnterGrowthVat.verb>入る</EnterGrowthVat.verb>
   
   <!-- EN: enter subcore scanner -->
-  <EnterSubcoreScanner.label>TODO</EnterSubcoreScanner.label>
+  <EnterSubcoreScanner.label>サブコアスキャナーに入る</EnterSubcoreScanner.label>
   <!-- EN: entering -->
-  <EnterSubcoreScanner.gerund>TODO</EnterSubcoreScanner.gerund>
+  <EnterSubcoreScanner.gerund>に入る</EnterSubcoreScanner.gerund>
   <!-- EN: enter -->
-  <EnterSubcoreScanner.verb>TODO</EnterSubcoreScanner.verb>
+  <EnterSubcoreScanner.verb>入る</EnterSubcoreScanner.verb>
   
   <!-- EN: administer hemogen -->
-  <FeedHemogen.label>TODO</FeedHemogen.label>
+  <FeedHemogen.label>ヘモゲンを与える</FeedHemogen.label>
   <!-- EN: administering hemogen to -->
-  <FeedHemogen.gerund>TODO</FeedHemogen.gerund>
+  <FeedHemogen.gerund>にヘモゲンを与える</FeedHemogen.gerund>
   <!-- EN: administer hemogen to -->
-  <FeedHemogen.verb>TODO</FeedHemogen.verb>
+  <FeedHemogen.verb>ヘモゲンを与える</FeedHemogen.verb>
   
   <!-- EN: haul mechs to charger -->
-  <HaulMechsToCharger.label>TODO</HaulMechsToCharger.label>
+  <HaulMechsToCharger.label>メカを充電器へ運搬</HaulMechsToCharger.label>
   <!-- EN: hauling -->
-  <HaulMechsToCharger.gerund>TODO</HaulMechsToCharger.gerund>
+  <HaulMechsToCharger.gerund>を運搬する</HaulMechsToCharger.gerund>
   <!-- EN: haul -->
-  <HaulMechsToCharger.verb>TODO</HaulMechsToCharger.verb>
+  <HaulMechsToCharger.verb>運搬</HaulMechsToCharger.verb>
   
   <!-- EN: haul resources to carrier -->
-  <HaulToCarrier.label>TODO</HaulToCarrier.label>
+  <HaulToCarrier.label>材料をキャリアーへ運搬</HaulToCarrier.label>
   <!-- EN: hauling to -->
-  <HaulToCarrier.gerund>TODO</HaulToCarrier.gerund>
+  <HaulToCarrier.gerund>へ運搬する</HaulToCarrier.gerund>
   <!-- EN: haul to -->
-  <HaulToCarrier.verb>TODO</HaulToCarrier.verb>
+  <HaulToCarrier.verb>運搬</HaulToCarrier.verb>
   
   <!-- EN: bank genepack -->
-  <HaulToGeneBank.label>TODO</HaulToGeneBank.label>
+  <HaulToGeneBank.label>遺伝子パックを保存</HaulToGeneBank.label>
   <!-- EN: banking -->
-  <HaulToGeneBank.gerund>TODO</HaulToGeneBank.gerund>
+  <HaulToGeneBank.gerund>を保存する</HaulToGeneBank.gerund>
   <!-- EN: bank -->
-  <HaulToGeneBank.verb>TODO</HaulToGeneBank.verb>
+  <HaulToGeneBank.verb>保存</HaulToGeneBank.verb>
   
   <!-- EN: carry to growth vat -->
-  <HaulToGrowthVat.label>TODO</HaulToGrowthVat.label>
+  <HaulToGrowthVat.label>成長バットへ運搬</HaulToGrowthVat.label>
   <!-- EN: filling -->
-  <HaulToGrowthVat.gerund>TODO</HaulToGrowthVat.gerund>
+  <HaulToGrowthVat.gerund>へ運搬する</HaulToGrowthVat.gerund>
   <!-- EN: fill -->
-  <HaulToGrowthVat.verb>TODO</HaulToGrowthVat.verb>
+  <HaulToGrowthVat.verb>運搬</HaulToGrowthVat.verb>
   
   <!-- EN: haul resources to subcore scanner -->
-  <HaulToSubcoreScanner.label>TODO</HaulToSubcoreScanner.label>
+  <HaulToSubcoreScanner.label>材料をサブコアスキャナーへ運搬</HaulToSubcoreScanner.label>
   <!-- EN: hauling to -->
-  <HaulToSubcoreScanner.gerund>TODO</HaulToSubcoreScanner.gerund>
+  <HaulToSubcoreScanner.gerund>へ運搬する</HaulToSubcoreScanner.gerund>
   <!-- EN: haul to -->
-  <HaulToSubcoreScanner.verb>TODO</HaulToSubcoreScanner.verb>
+  <HaulToSubcoreScanner.verb>運搬</HaulToSubcoreScanner.verb>
   
   <!-- EN: haul resources to wastepack atomizer -->
-  <HaulToWastepackAtomizer.label>TODO</HaulToWastepackAtomizer.label>
+  <HaulToWastepackAtomizer.label>材料を廃棄物パック分解装置へ運搬</HaulToWastepackAtomizer.label>
   <!-- EN: hauling to -->
-  <HaulToWastepackAtomizer.gerund>TODO</HaulToWastepackAtomizer.gerund>
+  <HaulToWastepackAtomizer.gerund>へ運搬する</HaulToWastepackAtomizer.gerund>
   <!-- EN: haul to -->
-  <HaulToWastepackAtomizer.verb>TODO</HaulToWastepackAtomizer.verb>
+  <HaulToWastepackAtomizer.verb>運搬</HaulToWastepackAtomizer.verb>
   
   <!-- EN: play with babies -->
-  <PlayWithBaby.label>TODO</PlayWithBaby.label>
+  <PlayWithBaby.label>赤ん坊と遊ぶ</PlayWithBaby.label>
   <!-- EN: playing with -->
-  <PlayWithBaby.gerund>TODO</PlayWithBaby.gerund>
+  <PlayWithBaby.gerund>と遊ぶ</PlayWithBaby.gerund>
   <!-- EN: play with -->
-  <PlayWithBaby.verb>TODO</PlayWithBaby.verb>
+  <PlayWithBaby.verb>遊ぶ</PlayWithBaby.verb>
   
   <!-- EN: repair mech -->
-  <RepairMech.label>TODO</RepairMech.label>
+  <RepairMech.label>メカを修理</RepairMech.label>
   <!-- EN: repairing -->
-  <RepairMech.gerund>TODO</RepairMech.gerund>
+  <RepairMech.gerund>を修理する</RepairMech.gerund>
   <!-- EN: repair -->
-  <RepairMech.verb>TODO</RepairMech.verb>
+  <RepairMech.verb>修理</RepairMech.verb>
   
 </LanguageData>


### PR DESCRIPTION
WorkGiverDefを翻訳しました。固有名詞は後程すり合わせとします。
babyは赤ん坊で一旦統一しました。
mech gestator
gene extractor
growth vat
