### PR TITLE
Pull request: Fix: Royalty 1.4.3558

### DIFF
--- a/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Refugee.xml
+++ b/Royalty/DefInjected/QuestScriptDef/Script_Hospitality_Refugee.xml
@@ -293,7 +293,7 @@
     <li>areIs(lodgerCount>=2)->are</li>
   -->
   <RefugeeBetrayal.questDescriptionRules.rulesStrings>
-    <li>questDescription->[factionOpponent_faction_name]の[factionOpponent_faction_pawnSingular]である[factionOpponent_nameDef]は,[asker_nameDef][otherLodgers][areIs]が[map_defined]に滞在していることを知りました.[factionOpponent_pronoun]は[asker_nameDef]を敵とみなしており,[asker_objective]死を望んでいます.\n\n[factionOpponent_pronoun]は,[faction_name]のすべてのメンバーを倒すと次の報酬を与えます(総価値 [betrayalRewardMarketValue_money]):\n\n[betrayalRewards]</li>
+    <li>questDescription->[factionOpponent_faction_name]の[factionOpponent_faction_pawnSingular]である[factionOpponent_nameDef]は,[asker_nameDef][otherLodgers][areIs]が[map_definite]に滞在していることを知りました.[factionOpponent_pronoun]は[asker_nameDef]を敵とみなしており,[asker_objective]死を望んでいます.\n\n[factionOpponent_pronoun]は,[faction_name]のすべてのメンバーを倒すと次の報酬を与えます(総価値 [betrayalRewardMarketValue_money]):\n\n[betrayalRewards]</li>
     <li>lodgersLabelSingularOrPlural(lodgerCount==1)->[lodgersLabel]</li>
     <li>lodgersLabelSingularOrPlural(lodgerCount>=2)->[lodgersLabelPlural]</li>
     <li>otherLodgers(lodgerCount==1)-></li>


### PR DESCRIPTION
Line 269

  <!-- EN: -->
    <li>questDescription->[factionOpponent_nameDef], a [factionOpponent_faction_pawnSingular] of [factionOpponent_faction_name], has learned that [asker_nameDef] [otherLodgers] [areIs] being hosted at [map_definite]. [factionOpponent_pronoun] is enemies with [asker_nameDef] and wants to see [asker_objective] dead.\n\n[factionOpponent_pronoun] will send you the following reward if you kill all members of [faction_name] (total value [betrayalRewardMarketValue_money]):\n\n[betrayalRewards]</li>

  <!-- Japanese -->

<li>questDescription->[factionOpponent_faction_name]の[factionOpponent_faction_pawnSingular]である[factionOpponent_nameDef]は,[asker_nameDef][otherLodgers][areIs]が[map_defined]に滞在していることを知りました.[factionOpponent_pronoun]は[asker_nameDef]を敵とみなしており,[asker_objective]死を望んでいます.\n\n[factionOpponent_pronoun]は,[faction_name]のすべてのメンバーを倒すと次の報酬を与えます(総価値 [betrayalRewardMarketValue_money]):\n\n[betrayalRewards]</li>

正 : [map_definite]
誤 : [map_defined]

Fixed :

<li>questDescription->[factionOpponent_faction_name]の[factionOpponent_faction_pawnSingular]である[factionOpponent_nameDef]は,[asker_nameDef][otherLodgers][areIs]が[map_definite]に滞在していることを知りました.[factionOpponent_pronoun]は[asker_nameDef]を敵とみなしており,[asker_objective]死を望んでいます.\n\n[factionOpponent_pronoun]は,[faction_name]のすべてのメンバーを倒すと次の報酬を与えます(総価値 [betrayalRewardMarketValue_money]):\n\n[betrayalRewards]</li>

Report from
RimWorld 251日目 251  ID:TGtG+lVw0
https://egg.5ch.net/test/read.cgi/game/1669271249/251