### PR TITLE
Localize 1.4.3563

### DIFF
--- a/Ideology/DefInjected/PreceptDef/Precepts_Role.xml
+++ b/Ideology/DefInjected/PreceptDef/Precepts_Role.xml
@@ -3,8 +3,8 @@
   
   <!-- EN: Animals specialist -->
   <IdeoRole_AnimalsSpecialist.label>動物のスペシャリスト</IdeoRole_AnimalsSpecialist.label>
-  <!-- EN: A special ideoligious status focusing on animals to the exclusion of all else. This specialized role gives increased taming and training efficiency, and the ability to boost the animals-related abilities of nearby allies. Holders of this role will refuse to perform some non-animals-related tasks. -->
-  <IdeoRole_AnimalsSpecialist.description>全てを捨てて動物にのみ焦点を当てた特別な思想的地位です.この専門的な役割により,手懐けと調教の効率が上がり,近くの仲間の動物関連の能力を高めることができます.この役割の持ち主は,動物に関係ない仕事のいくつかを拒否します.</IdeoRole_AnimalsSpecialist.description>
+  <!-- EN: A special ideoligious status focusing on animals to the exclusion of all else. This specialized role gives increased taming and training efficiency. Holders of this role will refuse to perform some non-animals-related tasks. -->
+  <IdeoRole_AnimalsSpecialist.description>全てを捨てて動物にのみ焦点を当てた特別な思想的地位です.この専門的な役割により,手懐けと調教の効率が向上します.この役割の持ち主は,動物に関係ない仕事のいくつかを拒否します.</IdeoRole_AnimalsSpecialist.description>
   
   <!-- EN: leader -->
   <IdeoRole_Leader.label>リーダー</IdeoRole_Leader.label>


### PR DESCRIPTION
<IdeoRole_AnimalsSpecialist.description> changed.

"A special ideoligious status focusing on animals to the exclusion of all else. This specialized role gives increased taming and training efficiency, and the ability to boost the animals-related abilities of nearby allies. Holders of this role will refuse to perform some non-animals-related tasks."

was change to ;

"A special ideoligious status focusing on animals to the exclusion of all else. This specialized role gives increased taming and training efficiency. Holders of this role will refuse to perform some non-animals-related tasks."

"動物のスペシャリスト" description japanese translation;
"全てを捨てて動物にのみ焦点を当てた特別な思想的地位です.この専門的な役割により,手懐けと調教の効率が上がり,近くの仲間の動物関連の能力を高めることができます.この役割の持ち主は,動物に関係ない仕事のいくつかを拒否します."

to "全てを捨てて動物にのみ焦点を当てた特別な思想的地位です.この専門的な役割により,手懐けと調教の効率が向上します.この役割の持ち主は,動物に関係ない仕事のいくつかを拒否します."