### PR TITLE
訳語修正（主に死眠関連）

### DIFF
--- a/Biotech/DefInjected/GeneDef/GeneDefs_Sanguophage.xml
+++ b/Biotech/DefInjected/GeneDef/GeneDefs_Sanguophage.xml
@@ -51,7 +51,7 @@
   <!-- EN: deathrest -->
   <Deathrest.label>死眠</Deathrest.label>
   <!-- EN: Carriers of this gene must periodically regenerate themselves in a special coma called deathrest. Deathrest takes days, but can confer substantial bonuses. Deathrest can be accelerated and its effects enhanced by the use of a variety of special buildings and technologies.\n\nThose who put off deathresting will suffer from deathrest exhaustion. -->
-  <Deathrest.description>この遺伝子を持つ者は死眠と呼ばれる特別な昏睡状態で定期的に再生する必要があります.死眠には数日かかりますが,大幅なボーナスが得られます.死眠はさまざまな特別な建物や技術を使用することで加速し,その効果を高めることができます.\n\n死眠を先延ばしにすることもできますが,死眠の疲労に苦しむことになります.</Deathrest.description>
+  <Deathrest.description>この遺伝子を持つ者は死眠と呼ばれる特別な昏睡状態で定期的に再生する必要があります.死眠には数日かかりますが,大幅なボーナスが得られます.死眠はさまざまな特別な建物や技術を使用することで加速し,その効果を高めることができます.\n\n死眠を先延ばしにすることもできますが,死眠不足に苦しむことになります.</Deathrest.description>
   <!-- EN: death -->
   <Deathrest.symbolPack.prefixSymbols.0.symbol>デス</Deathrest.symbolPack.prefixSymbols.0.symbol>
   <!-- EN: dead -->

--- a/Biotech/DefInjected/HediffDef/Hediffs_Various.xml
+++ b/Biotech/DefInjected/HediffDef/Hediffs_Various.xml
@@ -12,7 +12,7 @@
   <Deathrest.description>昏睡のような深い眠りが数日間続き,肉体を修復します.特定の遺伝子を持つ者は死眠を行う必要があります.死眠者に特殊効果を与えるさまざまな支援設備で,死眠を強化することができます.</Deathrest.description>
   
   <!-- EN: deathrest exhaustion -->
-  <DeathrestExhaustion.label>死眠前の消耗</DeathrestExhaustion.label>
+  <DeathrestExhaustion.label>死眠不足</DeathrestExhaustion.label>
   <!-- EN: This person desperately needs to deathrest to rebalance their metabolism. -->
   <DeathrestExhaustion.description>この人物は生体内代謝を再調整するために死眠を渇望しています.</DeathrestExhaustion.description>
   

--- a/Biotech/DefInjected/NeedDef/Needs.xml
+++ b/Biotech/DefInjected/NeedDef/Needs.xml
@@ -4,7 +4,7 @@
   <!-- EN: deathrest -->
   <Deathrest.label>死眠</Deathrest.label>
   <!-- EN: People with the deathrest gene must deathrest every few days or quadrums. Deathresting means entering a regenerative coma for several days, during which the rester appears dead.\n\nA variety of special buildings can connect to a deathresting person and give them bonuses upon waking.\n\nGoing too long without deathrest will cause deathrest exhaustion, which massively degrades a person's physical capacities. -->
-  <Deathrest.description>死眠遺伝子を持つ人は数日,もしくは1季節おきに死眠を行う必要があります.死眠とは,死眠者が数日間の再生性昏睡状態に入ることを意味し,その姿はまるで死んでいるかのように見えます.\n\nさまざまな特別な建築物を死眠中の人物に接続でき,目覚めたときにボーナスを与えることができます.\n\n死眠なしで長時間過ごすと,死眠の枯渇が発生し,身体能力を大幅に低下させます.</Deathrest.description>
+  <Deathrest.description>死眠遺伝子を持つ人は数日,もしくは1季節おきに死眠を行う必要があります.死眠とは,死眠者が数日間の再生性昏睡状態に入ることを意味し,その姿はまるで死んでいるかのように見えます.\n\nさまざまな特別な建築物を死眠中の人物に接続でき,目覚めたときにボーナスを与えることができます.\n\n死眠なしで長時間過ごすと,死眠不足が発生し,身体能力を大幅に低下させます.</Deathrest.description>
   
   <!-- EN: kill satiety -->
   <KillThirst.label>殺しの喜び</KillThirst.label>

--- a/Biotech/DefInjected/ThoughtDef/Thoughts_Situation_Special.xml
+++ b/Biotech/DefInjected/ThoughtDef/Thoughts_Situation_Special.xml
@@ -38,7 +38,7 @@
   <!-- EN: good deathrest chamber -->
   <DeathrestChamber.stages.good_deathrest_chamber.label>良い死眠室</DeathrestChamber.stages.good_deathrest_chamber.label>
   <!-- EN: I deathrested in a slightly impressive chamber. It was nice. -->
-  <DeathrestChamber.stages.good_deathrest_chamber.description>多少印象的な死眠室で死眠した.良かったよ.</DeathrestChamber.stages.good_deathrest_chamber.description>
+  <DeathrestChamber.stages.good_deathrest_chamber.description>多少印象的な死眠室で死眠した.いい感じだった.</DeathrestChamber.stages.good_deathrest_chamber.description>
   <!-- EN: great deathrest chamber -->
   <DeathrestChamber.stages.great_deathrest_chamber.label>とても良い死眠室</DeathrestChamber.stages.great_deathrest_chamber.label>
   <!-- EN: I deathrested in an impressive chamber. I feel rejuvenated. -->
@@ -50,7 +50,7 @@
   <!-- EN: exceptional deathrest chamber -->
   <DeathrestChamber.stages.exceptional_deathrest_chamber.label>格段に素晴らしい死眠室</DeathrestChamber.stages.exceptional_deathrest_chamber.label>
   <!-- EN: I deathrested in an extremely impressive chamber. It was glorious. -->
-  <DeathrestChamber.stages.exceptional_deathrest_chamber.description>極めて印象的な死眠室で死眠した.輝かんばかりだ.</DeathrestChamber.stages.exceptional_deathrest_chamber.description>
+  <DeathrestChamber.stages.exceptional_deathrest_chamber.description>極めて印象的な死眠室で死眠した.壮観だった.</DeathrestChamber.stages.exceptional_deathrest_chamber.description>
   <!-- EN: unbelievable deathrest chamber -->
   <DeathrestChamber.stages.unbelievable_deathrest_chamber.label>信じられないほど素晴らしい死眠室</DeathrestChamber.stages.unbelievable_deathrest_chamber.label>
   <!-- EN: I deathrested in an unbelievably impressive chamber. It was spectacular. -->
@@ -61,7 +61,7 @@
   <DeathrestChamber.stages.wondrous_deathrest_chamber.description>あんなにも豪華な死眠室で死眠できるとは!驚異的だ.</DeathrestChamber.stages.wondrous_deathrest_chamber.description>
   
   <!-- EN: deathrest exhaustion -->
-  <DeathrestExhaustion.stages.deathrest_exhaustion.label>死眠前の消耗</DeathrestExhaustion.stages.deathrest_exhaustion.label>
+  <DeathrestExhaustion.stages.deathrest_exhaustion.label>死眠不足</DeathrestExhaustion.stages.deathrest_exhaustion.label>
   <!-- EN: The casket calls and I fall weary. The world's pall makes all so dreary. I need to deathrest. -->
   <DeathrestExhaustion.stages.deathrest_exhaustion.description>棺が私を呼んでおり,私は疲れ果てた.世界に帳が下り,全てが陰気に変わってゆく.死眠する必要がある.</DeathrestExhaustion.stages.deathrest_exhaustion.description>
   
@@ -77,11 +77,11 @@
   <!-- EN: apocriton hatred (strong) -->
   <HateAura.stages.apocriton_hatred_strong.label>アポクリトンの憎悪(強)</HateAura.stages.apocriton_hatred_strong.label>
   <!-- EN: I hear its hatred echoing between my thoughts. Reasons, always reasons why my friends ought to die. -->
-  <HateAura.stages.apocriton_hatred_strong.description>私はソレの憎悪が私の思考の間に反響するのを聴いている.理由,常に私の友人たちが死なねばならない理由.</HateAura.stages.apocriton_hatred_strong.description>
+  <HateAura.stages.apocriton_hatred_strong.description>私はソレの憎悪が私の思考の間に反響するのを聴いている.理由,私の友人たちがいつ死んでもいい理由.</HateAura.stages.apocriton_hatred_strong.description>
   <!-- EN: apocriton hatred (distant) -->
   <HateAura.stages.apocriton_hatred_distant.label>アポクリトンの憎悪(弱)</HateAura.stages.apocriton_hatred_distant.label>
   <!-- EN: I feel it out there somewhere. It's always thinking about why these people deserve death. Always following the logic of murder. Hard to ignore. -->
-  <HateAura.stages.apocriton_hatred_distant.description>どこかにソレがいるのを感じる.ソレはいつも人々がなぜ死に値するのか考えている.常に殺戮の論理に従っている.無視するのは困難だ.</HateAura.stages.apocriton_hatred_distant.description>
+  <HateAura.stages.apocriton_hatred_distant.description>どこかにソレがいるのを感じる.ソレはいつも人々がなぜ死ぬべきなのか考えている.常に殺戮の論理に従っている.無視するのは困難だ.</HateAura.stages.apocriton_hatred_distant.description>
   
   <!-- EN: hemogen craving -->
   <HemogenCraving.stages.hemogen_craving-0.label>ヘモゲンの渇望</HemogenCraving.stages.hemogen_craving-0.label>
@@ -99,7 +99,7 @@
   <!-- EN: kill thirst -->
   <KillThirst.stages.kill_thirst.label>殺しの渇き</KillThirst.stages.kill_thirst.label>
   <!-- EN: Must kill... it has been too long since I have killed somebody up close and personal. -->
-  <KillThirst.stages.kill_thirst.description>殺さなきゃ...こんなに近くで個人的に誰かを殺すのは久しぶりだ.</KillThirst.stages.kill_thirst.description>
+  <KillThirst.stages.kill_thirst.description>殺さなきゃ...こんな目の前の誰かを殺すのは久しぶりだ.</KillThirst.stages.kill_thirst.description>
   
   <!-- EN: acidic smog -->
   <NoxiousHaze.stages.acidic_smog.label>酸性スモッグ</NoxiousHaze.stages.acidic_smog.label>

--- a/Biotech/Keyed/Misc_Gameplay.xml
+++ b/Biotech/Keyed/Misc_Gameplay.xml
@@ -134,7 +134,7 @@
   <!-- EN: Wake up from deathrest.\n\n{PAWN_nameDef} has been in deathrest for {DURATION}. -->
   <WakeDesc>死眠から目覚めます.\n\n{PAWN_nameDef}は{DURATION}間死眠しています.</WakeDesc>
   <!-- EN: {PAWN_nameDef} needs to deathrest for at least {TOTAL}. Waking {PAWN_objective} early will make {PAWN_objective} ill, and {PAWN_pronoun} will not benefit from any deathrest buildings. -->
-  <WakeExtraDesc_Exhaustion>{PAWN_nameDef}は少なくとも{TOTAL}間死眠する必要があります.早起きすると病気になり,死眠用設備からの恩恵を得られません.</WakeExtraDesc_Exhaustion>
+  <WakeExtraDesc_Exhaustion>{PAWN_nameDef}は少なくとも{TOTAL}後までに死眠する必要があります.早起きすると病気になり,死眠用設備からの恩恵を得られません.</WakeExtraDesc_Exhaustion>
   <!-- EN: {PAWN_nameDef} can now wake safely. -->
   <WakeExtraDesc_Safe>{PAWN_nameDef}は安全に起きることができます.</WakeExtraDesc_Safe>
   <!-- EN: Cannot wake. Need at least {0} hemogen. -->
@@ -166,9 +166,9 @@
   <!-- EN: Regeneration rate -->
   <RegenerationRate>再生レート</RegenerationRate>
   <!-- EN: {PAWN_nameDef} should deathrest in {DURATION} to avoid exhaustion. -->
-  <NextDeathrestNeed>{PAWN_nameDef}は疲労を避けるため,{DURATION}間死眠する必要があります.</NextDeathrestNeed>
+  <NextDeathrestNeed>{PAWN_nameDef}は死眠不足を避けるため,{DURATION}間死眠する必要があります.</NextDeathrestNeed>
   <!-- EN: {PAWN_nameDef} should deathrest soon to avoid exhaustion. -->
-  <PawnShouldDeathrestNow>{PAWN_nameDef}は極度の疲労を避けるため,今すぐに死眠する必要があります.</PawnShouldDeathrestNow>
+  <PawnShouldDeathrestNow>{PAWN_nameDef}は死眠不足を避けるため,今すぐに死眠する必要があります.</PawnShouldDeathrestNow>
   <!-- EN: This determines whether {PAWN_nameDef} will automatically ingest hemogen packs when {PAWN_possessive} hemogen is below {MIN}.\n\nAutomatic ingestion is currently {ONOFF}. -->
   <AutoTakeHemogenDesc>この設定は,{PAWN_nameDef}のヘモゲン量が{MIN}を下回ったときに,ヘモゲンパックを自動で摂取するかどうかを決めます.\n\n自動摂取は現在{ONOFF}です.</AutoTakeHemogenDesc>
   <!-- EN: Consume hemogen below -->
@@ -184,9 +184,9 @@
 
   <!-- Deathrest buildings -->
   <!-- EN: Bound to -->
-  <BoundTo>接続中</BoundTo>
+  <BoundTo>接続済</BoundTo>
   <!-- EN: Will bind permanently on first use. -->
-  <WillBindOnFirstUse>最初の使用者と結びつけられます.</WillBindOnFirstUse>
+  <WillBindOnFirstUse>最初の使用者と永続的に結びつけられます.</WillBindOnFirstUse>
   <!-- EN: Time active this deathrest -->
   <TimeActiveThisDeathrest>この死眠のアクティブ時間</TimeActiveThisDeathrest>
   <!-- EN: Minimum is {0} to apply -->
@@ -512,7 +512,7 @@
   <!-- EN: Power cell -->
   <MechPowerCell>パワーコア</MechPowerCell>
   <!-- EN: War urchins have a one-time power source. When the power cell runs out, the mechanoid dies. -->
-  <MechPowerCellTip>ウォーアーチンは一度限りの動力源を持っています.このパワーコアがなくなると,メカノイドは停止します.</MechPowerCellTip>
+  <MechPowerCellTip>ウォーアーチンの動力源は使い捨てです.パワーコアの残量がなくなると,このメカノイドは停止します.</MechPowerCellTip>
   
 
   <!-- Bossgroup -->
@@ -652,7 +652,7 @@
   <!-- EN: Mech stun pulse on death -->
   <MechStunPulseWarning>死亡時のメカのスタンパルス</MechStunPulseWarning>
   <!-- EN: {PAWN_nameDef} is in self-shutdown from low energy. -->
-  <IsLowEnergySelfShutdown>{PAWN_nameDef}は低エネルギーによって自己停止します.</IsLowEnergySelfShutdown>
+  <IsLowEnergySelfShutdown>{PAWN_nameDef}は低エネルギーのため自己停止中です.</IsLowEnergySelfShutdown>
   
   <!-- Pollution -->
   <!-- EN: Toggle pollution overlay. This displays which areas of terrain are polluted.\n\nExposure to polluted terrain causes toxic buildup which can lead to death. Most plants cannot live on polluted terrain. -->


### PR DESCRIPTION
biotech関連の翻訳を修正。特に死眠関連の訳語を統一。
deathrest exhaustionを、sleep exhaustion（睡眠不足）に対応させて死眠不足として統一。