### PR TITLE
ダイニングとキッチンの訳語を分ける

### DIFF
--- a/Core/DefInjected/RoomRoleDef/RoomRoles.xml
+++ b/Core/DefInjected/RoomRoleDef/RoomRoles.xml
@@ -17,7 +17,7 @@
   <Hospital.label>医務室</Hospital.label>
   
   <!-- EN: kitchen -->
-  <Kitchen.label>食堂</Kitchen.label>
+  <Kitchen.label>調理場</Kitchen.label>
   
   <!-- EN: laboratory -->
   <Laboratory.label>研究室</Laboratory.label>


### PR DESCRIPTION
共に食堂になってしまっているのでキッチンを `FoodPoisonCause_FilthyKitchen` に合わせて調理場に変更